### PR TITLE
create a TODO page based on TODO in the frontmatter

### DIFF
--- a/contributing/index.md
+++ b/contributing/index.md
@@ -9,6 +9,8 @@ This site is primarily community built and supported. If you notice something is
 
 The source for this website is managed in a public [GitHug Repo.](https://github.com/railcore/railcore.github.io)  It's built using [Jekyll](https://jekyllrb.com) and hosted on [GitHub Pages](https://pages.github.com). While that sounds complicated, it just means most of the code is written in simple [Markdown](https://www.markdownguide.org/cheat-sheet/) and managed in public using free tools.
 
+Contributions are welcome throughout the site. If you need help finding a place to start, see our [TODO page.](/contributing/todo.html)
+
 ## Power Users
 
 If you're already familiar with GitHub, feel free to fork the project and submit a PR.  If that last sentence made no sense, the rest of this page is for you.

--- a/contributing/todo.md
+++ b/contributing/todo.md
@@ -1,0 +1,14 @@
+---
+title: railcore.github.io TODO List
+---
+The following is a list of pages that have been marked with `TODO` items in the front matter, along with a brief description of what's needed.
+
+Contributors: any progress at all is welcome, don't feel like you have to make a page perfect before you can contribute anything.  See our [Contributing](/contributing) page for more information on how to get started.
+
+Maintainers: if you see a page that needs work, add a `TODO` item in the page's frontmatter to make it show up on this list.
+
+{% for page in site.pages %}
+  {% if page.TODO  %}
+* [{{ page.title }}]({{ page.url }}) - {{ page.TODO }}
+  {% endif %}
+{% endfor %}

--- a/software/index.md
+++ b/software/index.md
@@ -2,6 +2,7 @@
 title: Software
 layout: category
 sidebar_sort_order: 3
+TODO: Expand into sections for initial Duet setup, customizing Duet config, and slicer config.
 ---
 
 


### PR DESCRIPTION
This adds a TODO page based on a TODO value in the front matter for any page.

We will still need to go in and add TODO notes on pages that needed edited.  We might as well also create stub pages with a TODO for items we know need done but have yet to be built, to make community contributions easier.