### PR TITLE
remove category layout

### DIFF
--- a/hardware/mag_bed_flex_plates.md
+++ b/hardware/mag_bed_flex_plates.md
@@ -1,6 +1,5 @@
 ---
 title: Magnetic Bed Solutions and Build Plates
-layout: category
 ---
 
 This section covers Magnetic Beds and Build Plates that will work with the RailCore.


### PR DESCRIPTION
This should not have a `layout: category` in the frontmatter, as that puts it as a top-level link in the sidebar nav.