### PR TITLE
Organize/expand customization page

### DIFF
--- a/customization/index.md
+++ b/customization/index.md
@@ -11,7 +11,7 @@ sidebar_sort_order: 4
 
 ## Hardware Customizations
   * [Machined/milled parts](./machined_parts.md) - machined parts can improve durability, strength and reduce mass
-  * [Bottom 1515 extrusion braces for RailCore 300ZL](https://imgur.com/tJIpFaI) - extra HFS3-1515-425 extrusions for bottom stiffness
+  * [Bottom 1515 extrusion braces for RailCore 300ZL](https://imgur.com/tJIpFaI) - extra HFS3-1515-425 extrusions for bottom stiffness.  A drill template with standardized spacing is [also available](https://www.thingiverse.com/thing:3561761)
   * [Community Modifications and Parts on Thingiverse](https://www.thingiverse.com/railcore/collections/300zl-zlt) - you'll find most of the various combinations of mounts for hot-ends, extruders and probes (on aluminium mounts or printed)
   * [Thermostatically Controlled Heatbreak Fan](./thermostatic_fan.md) - modifying the heatbreak fan to be thermostatically controlled quiets the machine when idle
 

--- a/customization/index.md
+++ b/customization/index.md
@@ -12,9 +12,10 @@ sidebar_sort_order: 4
 ## Hardware Customizations
   * [Machined/milled parts](./machined_parts.md) - machined parts can improve durability, strength and reduce mass
   * [Bottom 1515 extrusion braces for RailCore 300ZL](https://imgur.com/tJIpFaI) - extra HFS3-1515-425 extrusions for bottom stiffness.  A drill template with standardized spacing is [also available](https://www.thingiverse.com/thing:3561761)
-  * [Community Modifications and Parts on Thingiverse](https://www.thingiverse.com/railcore/collections/300zl-zlt) - you'll find most of the various combinations of mounts for hot-ends, extruders and probes (on aluminium mounts or printed)
+  * [Leadscrew Coupler Cover](https://www.thingiverse.com/thing:3629939) - a printable cover for the leadscrew couplers designed to keep garbage from wrapping around the screws/couplers.  Designed as a snap-fit with the bottom 1515 braces linked above.
   * [Thermostatically Controlled Heatbreak Fan](./thermostatic_fan.md) - modifying the heatbreak fan to be thermostatically controlled quiets the machine when idle
-  * [Leadsrew Coupler Cover](https://www.thingiverse.com/thing:3629939) - a printable cover for the leadscrew couplers designed to keep garbage from wrapping around the screws/couplers.  Designed as a snap-fit with the bottom 1515 braces linked above.
+
+  See also the [Community Modifications and Parts on Thingiverse](https://www.thingiverse.com/railcore/collections/300zl-zlt) You'll find various combinations of mounts for hot-ends, extruders and probes (on aluminium mounts or printed)
 
 ### Videos
 

--- a/customization/index.md
+++ b/customization/index.md
@@ -4,13 +4,16 @@ layout: category
 sidebar_sort_order: 4
 ---
 
-## Variations & Customizations
+## Software Customizations
 
-  * [Duet Switchless X/Y Homing](./duet_switchless_homing.md)
+  * [Switchless X/Y Homing with Duet](./duet_switchless_homing.md)
   * [Tool Offset Z configuration](./tool_offset_z_configuration.md)
+
+## Hardware Customizations
   * [Machined/milled parts](./machined_parts.md) - machined parts can improve durability, strength and reduce mass
   * [Bottom 1515 extrusion braces for RailCore 300ZL](https://imgur.com/tJIpFaI) - extra HFS3-1515-425 extrusions for bottom stiffness
   * [Community Modifications and Parts on Thingiverse](https://www.thingiverse.com/railcore/collections/300zl-zlt) - you'll find most of the various combinations of mounts for hot-ends, extruders and probes (on aluminium mounts or printed)
+  * [Thermostatically Controlled Heatbreak Fan](./thermostatic_fan.md) - modifying the heatbreak fan to be thermostatically controlled quiets the machine when idle
 
 ### Videos
 

--- a/customization/index.md
+++ b/customization/index.md
@@ -14,6 +14,7 @@ sidebar_sort_order: 4
   * [Bottom 1515 extrusion braces for RailCore 300ZL](https://imgur.com/tJIpFaI) - extra HFS3-1515-425 extrusions for bottom stiffness.  A drill template with standardized spacing is [also available](https://www.thingiverse.com/thing:3561761)
   * [Leadscrew Coupler Cover](https://www.thingiverse.com/thing:3629939) - a printable cover for the leadscrew couplers designed to keep garbage from wrapping around the screws/couplers.  Designed as a snap-fit with the bottom 1515 braces linked above.
   * [Thermostatically Controlled Heatbreak Fan](./thermostatic_fan.md) - modifying the heatbreak fan to be thermostatically controlled quiets the machine when idle
+  * [Bottom Panel for Electronics Enclosure](https://www.thingiverse.com/thing:3634362) - a printable panel to cover the bottom of the electronics enclosure to keep wayward fingers and pets away from the wiring
 
   See also the [Community Modifications and Parts on Thingiverse](https://www.thingiverse.com/railcore/collections/300zl-zlt) You'll find various combinations of mounts for hot-ends, extruders and probes (on aluminium mounts or printed)
 

--- a/customization/index.md
+++ b/customization/index.md
@@ -14,6 +14,7 @@ sidebar_sort_order: 4
   * [Bottom 1515 extrusion braces for RailCore 300ZL](https://imgur.com/tJIpFaI) - extra HFS3-1515-425 extrusions for bottom stiffness.  A drill template with standardized spacing is [also available](https://www.thingiverse.com/thing:3561761)
   * [Community Modifications and Parts on Thingiverse](https://www.thingiverse.com/railcore/collections/300zl-zlt) - you'll find most of the various combinations of mounts for hot-ends, extruders and probes (on aluminium mounts or printed)
   * [Thermostatically Controlled Heatbreak Fan](./thermostatic_fan.md) - modifying the heatbreak fan to be thermostatically controlled quiets the machine when idle
+  * [Leadsrew Coupler Cover](https://www.thingiverse.com/thing:3629939) - a printable cover for the leadscrew couplers designed to keep garbage from wrapping around the screws/couplers.  Designed as a snap-fit with the bottom 1515 braces linked above.
 
 ### Videos
 

--- a/customization/thermostatic_fan.md
+++ b/customization/thermostatic_fan.md
@@ -1,0 +1,15 @@
+---
+title: Thermostatic Heatbreak Fan
+---
+The hotend heatbreak fan can be thermostatically controlled to reduce noise when the printer is idle and cool.
+
+**Please note that there is some risk that if the Duet firmware crashes, this fan won't cool the hotend and a jam will happen.**
+
+Move the connector for the heatbreak fan from the "Always on Fans" connector to FAN1.  See the [wiring diagram](../build_and_troubleshoot/RailCore_wiring_diagram_with_12v_enablement-v2.pdf) to help find the connectors.
+
+Add the following to your `config.g` to enable thermostatic control of FAN1.
+```
+M106 P1 T45 H1
+```
+
+It is [recommended](https://duet3d.dozuki.com/Wiki/Connecting_and_configuring_fans#Section_Thermostatically_controlled_fans) to always use FAN1 for heatbreak fans as this connector is on at boot and is only turned off when the firmware detects it's safe to do so.  In practice your fan will turn on briefly when the machine starts up, then go silent if the hotend is cool.


### PR DESCRIPTION
I split the customization page up into hardware vs software and added a few entries to start filling that in.

I think as things coalesce over in the [parts issues](https://github.com/railcore/parts/issues) we should probably create a "recommended updates" section as well and start "promoting" certain upgrades to that list (anything that makes the kits, safety improvements, clear improvements that don't have a variety of alternatives).  This will help existing railcore owners identify the "must-have" improvements vs things that are optional.